### PR TITLE
fix(ci): Recover wedged auto-merge PRs from retry failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,5 +178,19 @@ jobs:
       run: |
         echo "🔄 Some tests failed, triggering automatic retry (attempt ${{ github.run_attempt }}/20)"
         echo "📊 Run ID: ${{ github.run_id }}"
-        gh workflow run retry.yml --field run_id=${{ github.run_id }}
+        # Retry the dispatch itself with backoff. The dispatch API occasionally
+        # returns transient 5xx errors; without this loop a single failure
+        # silently breaks the retry chain and wedges the PR until the scheduled
+        # backstop recovers it.
+        for attempt in 1 2 3 4 5; do
+          if gh workflow run retry.yml --field run_id=${{ github.run_id }}; then
+            echo "✅ Retry workflow dispatched (try $attempt)"
+            exit 0
+          fi
+          echo "⚠️ Dispatch attempt $attempt failed, retrying in $((attempt * 10))s..."
+          sleep $((attempt * 10))
+        done
+        echo "❌ Failed to dispatch retry workflow after 5 attempts"
+        echo "💡 The scheduled auto-merge job will retry as a backstop"
+        exit 1
 

--- a/scripts/check-and-retry-failed-jobs.sh
+++ b/scripts/check-and-retry-failed-jobs.sh
@@ -129,28 +129,33 @@ if [ "$DRY_RUN" = "true" ]; then
   echo "💡 To actually trigger retry, run without dry_run flag or set it to 'false'"
 else
   echo ""
-  echo "🚀 Triggering retry workflow..."
+  echo "🚀 Re-running failed jobs for run $latest_run_id..."
 
-  # Try to trigger retry, but don't fail if it doesn't work (e.g., token permissions)
+  # Re-run the failed jobs directly instead of dispatching retry.yml via
+  # workflow_dispatch. The dispatch endpoint (POST .../workflows/{id}/dispatches)
+  # requires the classic 'workflow' token scope, which PERSONAL_ACCESS_TOKEN does
+  # not have -- it returns HTTP 403 "Resource not accessible by personal access
+  # token", which silently wedges the PR forever. The rerun-failed-jobs endpoint
+  # only needs 'actions: write', already granted by the token's 'repo' scope. The
+  # run is already completed here, so we can re-run it directly without retry.yml.
+  # Don't fail the whole job if the rerun doesn't work.
   set +e
-  retry_output=$(gh workflow run retry.yml \
-    --repo "$REPOSITORY" \
-    --field run_id="$latest_run_id" 2>&1)
+  retry_output=$(gh run rerun "$latest_run_id" --failed --repo "$REPOSITORY" 2>&1)
   retry_exit_code=$?
   set -e
 
   if [ $retry_exit_code -eq 0 ]; then
-    echo "✅ Retry workflow triggered successfully"
-    echo "💡 A new workflow run will be created to retry the failed jobs"
-    echo "🔗 Monitor at: https://github.com/$REPOSITORY/actions/workflows/retry.yml"
+    echo "✅ Failed jobs re-run successfully"
+    echo "💡 A new attempt has started for the failed jobs"
+    echo "🔗 Monitor at: https://github.com/$REPOSITORY/actions/runs/$latest_run_id"
   else
-    echo "⚠️ Failed to trigger retry workflow (exit code: $retry_exit_code)"
+    echo "⚠️ Failed to re-run failed jobs (exit code: $retry_exit_code)"
     echo "Error output:"
     echo "$retry_output" | sed 's/^/  /'
     echo ""
     echo "Common causes:"
-    echo "  - Token lacks 'workflow' permission (HTTP 403)"
-    echo "  - Token lacks 'actions: write' scope"
+    echo "  - Token lacks 'actions: write' scope (HTTP 403)"
+    echo "  - Run is older than 30 days and can no longer be re-run"
     echo ""
     echo "💡 Continuing anyway - tests may have already passed"
     echo "💡 Check if PR is mergeable in the next cycle"


### PR DESCRIPTION
The automated flaky-test pipeline could deadlock on a single PR. Once a PR's checks failed, neither retry path could recover it, so the PR never merged, runs.txt never advanced, and no new automated PRs were created. PR #3373 sat stuck for three weeks for exactly this reason.

Two compounding failures caused it:

1. The scheduled backstop (runs every 30 minutes) tried to recover the failed PR by dispatching the retry workflow through the workflow_dispatch API. That endpoint requires the classic `workflow` token scope, but the personal access token only has `repo`, so every dispatch returned HTTP 403 and silently did nothing on every cycle. The fix re-runs the failed jobs directly. That endpoint needs only `actions: write`, which `repo` already grants, and the run is already complete by the time the backstop sees it, so the workflow indirection was unnecessary.

2. The in-CI retry trigger had no resilience. A single transient 5xx from the dispatch API permanently broke the retry chain, which is what stopped PR #3373 at attempt 6. It now retries the dispatch with bounded backoff so a transient error no longer wedges the PR.

The currently-stuck PR #3373 has been manually re-run to unblock the pipeline; this change prevents the deadlock from recurring.